### PR TITLE
Added CSA::Stationfactory cache and platforms data

### DIFF
--- a/src/linkedconnections/csa/csastation.cpp
+++ b/src/linkedconnections/csa/csastation.cpp
@@ -47,8 +47,8 @@ CSA::Station::Station(QObject *parent)
  * @param const qreal &averageStopTimes
  * @param QObject *parent
  * @package CSA
- * @private
- * Constructs a CSA::NullStation according to the Null design pattern.
+ * @public
+ * Constructs a CSA::Station without facilities.
  */
 CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const qreal &averageStopTimes, QObject *parent) : QObject(parent)
 {
@@ -81,6 +81,7 @@ CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &n
     m_hasHearingAidSignal = false;
     m_openingHours = QMap<CSA::Station::Day, QPair<QTime, QTime> >();
     m_averageStopTimes = averageStopTimes;
+    m_platforms = QList<QPair<QUrl, QString> >();
 }
 
 /**
@@ -113,8 +114,8 @@ CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &n
  * @param const qreal &averageStopTimes
  * @param QObject *parent
  * @package CSA
- * @private
- * Constructs a CSA::NullStation according to the Null design pattern.
+ * @public
+ * Constructs a CSA::Station with facilities.
  */
 CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const QGeoAddress &address, const bool &hasTicketVendingMachine, const bool &hasLuggageLockers, const bool &hasFreeParking, const bool &hasTaxi, const bool &hasBicycleSpots, const bool &hasBlueBike, const bool &hasBus, const bool &hasTram, const bool &hasMetro, const bool &hasWheelchairAvailable, const bool &hasRamp, const qint16 &disabledParkingSpots, const bool &hasElevatedPlatform, const bool &hasEscalatorUp, const bool &hasEscalatorDown, const bool &hasElevatorPlatform, const bool &hasHearingAidSignal, const QMap<CSA::Station::Day, QPair<QTime, QTime> > &openingHours, const qreal &averageStopTimes, QObject *parent) : QObject(parent)
 {
@@ -146,6 +147,123 @@ CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &n
     m_hasHearingAidSignal = hasHearingAidSignal;
     m_openingHours = openingHours;
     m_averageStopTimes = averageStopTimes;
+    m_platforms = QList<QPair<QUrl, QString> >();
+}
+
+/**
+ * @file csastation.cpp
+ * @author Dylan Van Assche
+ * @date 09 Aug 2018
+ * @brief CSA::Station constructor: minimal
+ * @param const QUrl &uri
+ * @param const QMap<QLocale::Language, QString> &name
+ * @param const QLocale::Country &country
+ * @param const QGeoCoordinate &position
+ * @param const qreal &averageStopTimes
+ * @param QObject *parent
+ * @package CSA
+ * @public
+ * Constructs a CSA::Station without facilities.
+ */
+CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const qreal &averageStopTimes, const QList<QPair<QUrl, QString> > &platforms, QObject *parent) : QObject(parent)
+{
+    // Clean up when parent dies
+    this->setParent(parent);
+
+    // Use private members to avoid signal firing on construction
+    // Unknown fields are set to a default value to avoid undefined references
+    m_uri = uri;
+    m_name = name;
+    m_country = country;
+    m_position = position;
+    m_address = QGeoAddress();
+    m_hasTicketVendingMachine = false;
+    m_hasLuggageLockers = false;
+    m_hasFreeParking = false;
+    m_hasTaxi = false;
+    m_hasBicycleSpots = false;
+    m_hasBlueBike = false;
+    m_hasBus = false;
+    m_hasTram = false;
+    m_hasMetro = false;
+    m_hasWheelchairAvailable = false;
+    m_hasRamp = false;
+    m_disabledParkingSpots = 0;
+    m_hasElevatedPlatform = false;
+    m_hasEscalatorUp = false;
+    m_hasEscalatorDown = false;
+    m_hasElevatorPlatform = false;
+    m_hasHearingAidSignal = false;
+    m_openingHours = QMap<CSA::Station::Day, QPair<QTime, QTime> >();
+    m_averageStopTimes = averageStopTimes;
+    m_platforms = platforms;
+}
+
+/**
+ * @file csastation.cpp
+ * @author Dylan Van Assche
+ * @date 09 Aug 2018
+ * @brief CSA::Station constructor: full
+ * @param const QUrl &uri
+ * @param const QMap<QLocale::Language, QString> &name
+ * @param const QLocale::Country &country
+ * @param const QGeoCoordinate &position
+ * @param const QGeoAddress &address
+ * @param const bool &hasTicketVendingMachine
+ * @param const bool &hasLuggageLockers
+ * @param const bool &hasFreeParking
+ * @param const bool &hasTaxi
+ * @param const bool &hasBicyclSpots
+ * @param const bool &hasBus
+ * @param const bool &hasTram
+ * @param const bool &hasMetro
+ * @param const bool &hasWheelchairAvailable
+ * @param const bool &hasRamp
+ * @param const qint16 &disabledParkingSpots
+ * @param const bool &hasElevatedPlatform
+ * @param const bool &hasEscalatorUp
+ * @param const bool &hasEscalatorDown
+ * @param const bool &hasElevatorPlatform
+ * @param const bool &hasHearingAidSignal
+ * @param const QMap<CSA::Station::Day, QPair<QTime, QTime>> &openingHours
+ * @param const QList<QPair<QUrl, QString> > &platforms
+ * @param const qreal &averageStopTimes
+ * @param QObject *parent
+ * @package CSA
+ * @public
+ * Constructs a CSA::Station with facilities and platforms.
+ */
+CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const QGeoAddress &address, const bool &hasTicketVendingMachine, const bool &hasLuggageLockers, const bool &hasFreeParking, const bool &hasTaxi, const bool &hasBicycleSpots, const bool &hasBlueBike, const bool &hasBus, const bool &hasTram, const bool &hasMetro, const bool &hasWheelchairAvailable, const bool &hasRamp, const qint16 &disabledParkingSpots, const bool &hasElevatedPlatform, const bool &hasEscalatorUp, const bool &hasEscalatorDown, const bool &hasElevatorPlatform, const bool &hasHearingAidSignal, const QMap<CSA::Station::Day, QPair<QTime, QTime> > &openingHours, const qreal &averageStopTimes, const QList<QPair<QUrl, QString> > &platforms, QObject *parent) : QObject(parent)
+{
+    // Clean up when parent dies
+    this->setParent(parent);
+
+    // Use private members to avoid signal firing on construction
+    m_uri = uri;
+    m_name = name;
+    m_country = country;
+    m_position = position;
+    m_address = address;
+    m_hasTicketVendingMachine = hasTicketVendingMachine;
+    m_hasLuggageLockers = hasLuggageLockers;
+    m_hasFreeParking = hasFreeParking;
+    m_hasTaxi = hasTaxi;
+    m_hasBicycleSpots = hasBicycleSpots;
+    m_hasBlueBike = hasBlueBike;
+    m_hasBus = hasBus;
+    m_hasTram = hasTram;
+    m_hasMetro = hasMetro;
+    m_hasWheelchairAvailable = hasWheelchairAvailable;
+    m_hasRamp = hasRamp;
+    m_disabledParkingSpots = disabledParkingSpots;
+    m_hasElevatedPlatform = hasElevatedPlatform;
+    m_hasEscalatorUp = hasEscalatorUp;
+    m_hasEscalatorDown = hasEscalatorDown;
+    m_hasElevatorPlatform = hasElevatorPlatform;
+    m_hasHearingAidSignal = hasHearingAidSignal;
+    m_openingHours = openingHours;
+    m_averageStopTimes = averageStopTimes;
+    m_platforms = platforms;
 }
 
 /**
@@ -895,4 +1013,36 @@ void CSA::Station::setAverageStopTimes(const qreal &averageStopTimes)
 {
     m_averageStopTimes = averageStopTimes;
     emit this->averageStopTimesChanged();
+}
+
+/**
+ * @file csastation.cpp
+ * @author Dylan Van Assche
+ * @date 09 Aug 2018
+ * @brief Gets the platforms for the station
+ * @package CSA
+ * @return const QList<QPair<QUrl, QString> > platforms
+ * @public
+ * Gets the platforms for the station and returns it.
+ */
+QList<QPair<QUrl, QString> > CSA::Station::platforms() const
+{
+    return m_platforms;
+}
+
+/**
+ * @file csastation.cpp
+ * @author Dylan Van Assche
+ * @date 09 Aug 2018
+ * @brief Sets platforms for the station
+ * @package CSA
+ * @param const QList<QPair<QUrl, QString> > &platforms
+ * @public
+ * Sets the platforms for the station to the given QList<QPair<QUrl, QString> > &platforms.
+ * Emits the platformsChanged signal.
+ */
+void CSA::Station::setPlatforms(const QList<QPair<QUrl, QString> > &platforms)
+{
+    m_platforms = platforms;
+    emit this->platformsChanged();
 }

--- a/src/linkedconnections/csa/csastation.cpp
+++ b/src/linkedconnections/csa/csastation.cpp
@@ -81,7 +81,7 @@ CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &n
     m_hasHearingAidSignal = false;
     m_openingHours = QMap<CSA::Station::Day, QPair<QTime, QTime> >();
     m_averageStopTimes = averageStopTimes;
-    m_platforms = QList<QPair<QUrl, QString> >();
+    m_platforms = QMap<QUrl, QString>();
 }
 
 /**
@@ -147,7 +147,7 @@ CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &n
     m_hasHearingAidSignal = hasHearingAidSignal;
     m_openingHours = openingHours;
     m_averageStopTimes = averageStopTimes;
-    m_platforms = QList<QPair<QUrl, QString> >();
+    m_platforms = QMap<QUrl, QString>();
 }
 
 /**
@@ -165,7 +165,7 @@ CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &n
  * @public
  * Constructs a CSA::Station without facilities.
  */
-CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const qreal &averageStopTimes, const QList<QPair<QUrl, QString> > &platforms, QObject *parent) : QObject(parent)
+CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const qreal &averageStopTimes, const QMap<QUrl, QString> &platforms, QObject *parent) : QObject(parent)
 {
     // Clean up when parent dies
     this->setParent(parent);
@@ -233,7 +233,7 @@ CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &n
  * @public
  * Constructs a CSA::Station with facilities and platforms.
  */
-CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const QGeoAddress &address, const bool &hasTicketVendingMachine, const bool &hasLuggageLockers, const bool &hasFreeParking, const bool &hasTaxi, const bool &hasBicycleSpots, const bool &hasBlueBike, const bool &hasBus, const bool &hasTram, const bool &hasMetro, const bool &hasWheelchairAvailable, const bool &hasRamp, const qint16 &disabledParkingSpots, const bool &hasElevatedPlatform, const bool &hasEscalatorUp, const bool &hasEscalatorDown, const bool &hasElevatorPlatform, const bool &hasHearingAidSignal, const QMap<CSA::Station::Day, QPair<QTime, QTime> > &openingHours, const qreal &averageStopTimes, const QList<QPair<QUrl, QString> > &platforms, QObject *parent) : QObject(parent)
+CSA::Station::Station(const QUrl &uri, const QMap<QLocale::Language, QString> &name, const QLocale::Country &country, const QGeoCoordinate &position, const QGeoAddress &address, const bool &hasTicketVendingMachine, const bool &hasLuggageLockers, const bool &hasFreeParking, const bool &hasTaxi, const bool &hasBicycleSpots, const bool &hasBlueBike, const bool &hasBus, const bool &hasTram, const bool &hasMetro, const bool &hasWheelchairAvailable, const bool &hasRamp, const qint16 &disabledParkingSpots, const bool &hasElevatedPlatform, const bool &hasEscalatorUp, const bool &hasEscalatorDown, const bool &hasElevatorPlatform, const bool &hasHearingAidSignal, const QMap<CSA::Station::Day, QPair<QTime, QTime> > &openingHours, const qreal &averageStopTimes, const QMap<QUrl, QString> &platforms, QObject *parent) : QObject(parent)
 {
     // Clean up when parent dies
     this->setParent(parent);
@@ -1021,11 +1021,11 @@ void CSA::Station::setAverageStopTimes(const qreal &averageStopTimes)
  * @date 09 Aug 2018
  * @brief Gets the platforms for the station
  * @package CSA
- * @return const QList<QPair<QUrl, QString> > platforms
+ * @return const QMap<QUrl, QString> platforms
  * @public
  * Gets the platforms for the station and returns it.
  */
-QList<QPair<QUrl, QString> > CSA::Station::platforms() const
+QMap<QUrl, QString> CSA::Station::platforms() const
 {
     return m_platforms;
 }
@@ -1036,12 +1036,12 @@ QList<QPair<QUrl, QString> > CSA::Station::platforms() const
  * @date 09 Aug 2018
  * @brief Sets platforms for the station
  * @package CSA
- * @param const QList<QPair<QUrl, QString> > &platforms
+ * @param const QMap<QUrl, QString> &platforms
  * @public
- * Sets the platforms for the station to the given QList<QPair<QUrl, QString> > &platforms.
+ * Sets the platforms for the station to the given QMap<QUrl, QString> &platforms.
  * Emits the platformsChanged signal.
  */
-void CSA::Station::setPlatforms(const QList<QPair<QUrl, QString> > &platforms)
+void CSA::Station::setPlatforms(const QMap<QUrl, QString> &platforms)
 {
     m_platforms = platforms;
     emit this->platformsChanged();

--- a/src/linkedconnections/csa/csastation.h
+++ b/src/linkedconnections/csa/csastation.h
@@ -83,6 +83,43 @@ public:
             const QMap<CSA::Station::Day, QPair<QTime, QTime>> &openingHours,
             const qreal &averageStopTimes,
             QObject *parent = nullptr);
+    // Without facilities and platforms
+    explicit Station(
+            const QUrl &uri,
+            const QMap<QLocale::Language, QString> &name,
+            const QLocale::Country &country,
+            const QGeoCoordinate &position,
+            const qreal &averageStopTimes,
+            const QList<QPair<QUrl, QString> > &platforms,
+            QObject *parent = nullptr);
+    // With facilities and platforms
+    explicit Station(
+            const QUrl &uri,
+            const QMap<QLocale::Language, QString> &name,
+            const QLocale::Country &country,
+            const QGeoCoordinate &position,
+            const QGeoAddress &address,
+            const bool &hasTicketVendingMachine,
+            const bool &hasLuggageLockers,
+            const bool &hasFreeParking,
+            const bool &hasTaxi,
+            const bool &hasBicycleSpots,
+            const bool &hasBlueBike,
+            const bool &hasBus,
+            const bool &hasTram,
+            const bool &hasMetro,
+            const bool &hasWheelchairAvailable,
+            const bool &hasRamp,
+            const qint16 &disabledParkingSpots,
+            const bool &hasElevatedPlatform,
+            const bool &hasEscalatorUp,
+            const bool &hasEscalatorDown,
+            const bool &hasElevatorPlatform,
+            const bool &hasHearingAidSignal,
+            const QMap<CSA::Station::Day, QPair<QTime, QTime>> &openingHours,
+            const qreal &averageStopTimes,
+            const QList<QPair<QUrl, QString> > &platforms,
+            QObject *parent = nullptr);
     QUrl uri() const;
     void setUri(const QUrl &uri);
     QMap<QLocale::Language, QString> name() const;
@@ -131,6 +168,8 @@ public:
     void setOpeningHours(const QMap<CSA::Station::Day, QPair<QTime, QTime> > &openingHours);
     qreal averageStopTimes() const;
     void setAverageStopTimes(const qreal &averageStopTimes);
+    QList<QPair<QUrl, QString> > platforms() const;
+    void setPlatforms(const QList<QPair<QUrl, QString> > &platforms);
 
 signals:
     void uriChanged();
@@ -156,6 +195,7 @@ signals:
     void hasHearingAidSignalChanged();
     void openingHoursChanged();
     void averageStopTimesChanged();
+    void platformsChanged();
 
 private:
     QUrl m_uri;
@@ -182,6 +222,7 @@ private:
     bool m_hasHearingAidSignal;
     QMap<CSA::Station::Day, QPair<QTime, QTime>> m_openingHours;
     qreal m_averageStopTimes;
+    QList<QPair<QUrl, QString>> m_platforms;
 
     Q_ENUM(Day)
 };

--- a/src/linkedconnections/csa/csastation.h
+++ b/src/linkedconnections/csa/csastation.h
@@ -90,7 +90,7 @@ public:
             const QLocale::Country &country,
             const QGeoCoordinate &position,
             const qreal &averageStopTimes,
-            const QList<QPair<QUrl, QString> > &platforms,
+            const QMap<QUrl, QString> &platforms,
             QObject *parent = nullptr);
     // With facilities and platforms
     explicit Station(
@@ -118,7 +118,7 @@ public:
             const bool &hasHearingAidSignal,
             const QMap<CSA::Station::Day, QPair<QTime, QTime>> &openingHours,
             const qreal &averageStopTimes,
-            const QList<QPair<QUrl, QString> > &platforms,
+            const QMap<QUrl, QString> &platforms,
             QObject *parent = nullptr);
     QUrl uri() const;
     void setUri(const QUrl &uri);
@@ -168,8 +168,8 @@ public:
     void setOpeningHours(const QMap<CSA::Station::Day, QPair<QTime, QTime> > &openingHours);
     qreal averageStopTimes() const;
     void setAverageStopTimes(const qreal &averageStopTimes);
-    QList<QPair<QUrl, QString> > platforms() const;
-    void setPlatforms(const QList<QPair<QUrl, QString> > &platforms);
+    QMap<QUrl, QString> platforms() const;
+    void setPlatforms(const QMap<QUrl, QString> &platforms);
 
 signals:
     void uriChanged();
@@ -222,7 +222,7 @@ private:
     bool m_hasHearingAidSignal;
     QMap<CSA::Station::Day, QPair<QTime, QTime>> m_openingHours;
     qreal m_averageStopTimes;
-    QList<QPair<QUrl, QString>> m_platforms;
+    QMap<QUrl, QString> m_platforms;
 
     Q_ENUM(Day)
 };

--- a/src/linkedconnections/csa/csastationfactory.cpp
+++ b/src/linkedconnections/csa/csastationfactory.cpp
@@ -727,12 +727,26 @@ CSA::Station *CSA::StationFactory::fetchStationFromCache(const QUrl &uri) const
  * @private
  * Adds a station to the memory cache to avoid duplicate CSA::Station objects.
  * This also reduces the look up time for station (less heavy database operations).
+ *
+ * BENCHMARK: Jolla 1 saves 400-500 ms by using this caching method for a single routing calculation.
  */
 void CSA::StationFactory::addStationToCache(CSA::Station *station)
 {
     this->m_cache.insert(station->uri(), station);
 }
 
+/**
+ * @file csastationfactory.cpp
+ * @author Dylan Van Assche
+ * @date 13 Aug 2018
+ * @brief Fetches the platforms of a station
+ * @param const QUrl &uri
+ * @return const QMap<QUrl, QString> platformsMap
+ * @package CSA
+ * @private
+ * Fetches the platforms of a station by URI from the database.
+ * The platforms are added in a QMap and returned.
+ */
 QMap<QUrl, QString> CSA::StationFactory::getPlatformsByStationURI(const QUrl &uri)
 {
     // Fetch platforms from database for a specific station URI.
@@ -747,18 +761,17 @@ QMap<QUrl, QString> CSA::StationFactory::getPlatformsByStationURI(const QUrl &ur
     this->db()->execute(query);
 
     // Read result and add the platforms to a QMap with their URI as ID.
-    QMap<QUrl, QString> platformList = QMap<QUrl, QString>();
+    QMap<QUrl, QString> platformsMap = QMap<QUrl, QString>();
 
     while (query.next())
     {
-        qDebug() << "STOP URI=" << query.value(0);
-        platformList.insert(
+        platformsMap.insert(
                     query.value(0).toUrl(), // Platform URI
                     query.value(2).toString() // Platform name
                     );
     }
 
-    return platformList;
+    return platformsMap;
 }
 
 // Getters & Setters

--- a/src/linkedconnections/csa/csastationfactory.h
+++ b/src/linkedconnections/csa/csastationfactory.h
@@ -48,9 +48,10 @@ private:
     bool initDatabase();
     bool insertStationWithFacilitiesIntoDatabase(const QStringList &station, const QStringList &facilities);
     bool insertStationWithoutFacilitiesIntoDatabase(const QStringList &station);
-    bool insertStopIntoDatabase(const QStringList &stop);
+    bool insertPlatformIntoDatabase(const QStringList &stop);
     CSA::Station *fetchStationFromCache(const QUrl &uri) const;
     void addStationToCache(CSA::Station *station);
+    QList<QPair<QUrl, QString>> getPlatformsByStationURI(const QUrl &uri);
     Database::Manager *db() const;
     void setDb(Database::Manager *db);
     static CSA::StationFactory *m_instance;

--- a/src/linkedconnections/csa/csastationfactory.h
+++ b/src/linkedconnections/csa/csastationfactory.h
@@ -24,6 +24,8 @@
 #include <QtCore/QString>
 #include <QtCore/QList>
 #include <QtCore/QStringList>
+#include <QtCore/QUrl>
+#include <QtCore/QMap>
 #include <QtSql/QSqlQuery>
 #include "csastation.h"
 #include "csanullstation.h"
@@ -51,7 +53,7 @@ private:
     bool insertPlatformIntoDatabase(const QStringList &stop);
     CSA::Station *fetchStationFromCache(const QUrl &uri) const;
     void addStationToCache(CSA::Station *station);
-    QList<QPair<QUrl, QString>> getPlatformsByStationURI(const QUrl &uri);
+    QMap<QUrl, QString> getPlatformsByStationURI(const QUrl &uri);
     Database::Manager *db() const;
     void setDb(Database::Manager *db);
     static CSA::StationFactory *m_instance;

--- a/src/linkedconnections/csa/csastationfactory.h
+++ b/src/linkedconnections/csa/csastationfactory.h
@@ -26,6 +26,7 @@
 #include <QtCore/QStringList>
 #include <QtSql/QSqlQuery>
 #include "csastation.h"
+#include "csanullstation.h"
 #include "../../database/databasemanager.h"
 #include "../qtcsv/include/qtcsv/stringdata.h"
 #include "../qtcsv/include/qtcsv/reader.h"
@@ -43,10 +44,13 @@ public:
 
 private:
     Database::Manager *m_db;
+    QMap<QUrl, CSA::Station*> m_cache;
     bool initDatabase();
     bool insertStationWithFacilitiesIntoDatabase(const QStringList &station, const QStringList &facilities);
     bool insertStationWithoutFacilitiesIntoDatabase(const QStringList &station);
     bool insertStopIntoDatabase(const QStringList &stop);
+    CSA::Station *fetchStationFromCache(const QUrl &uri) const;
+    void addStationToCache(CSA::Station *station);
     Database::Manager *db() const;
     void setDb(Database::Manager *db);
     static CSA::StationFactory *m_instance;

--- a/tests/csa/csaplannertest.cpp
+++ b/tests/csa/csaplannertest.cpp
@@ -101,10 +101,5 @@ void CSA::PlannerTest::processRouteFound(const QList<CSA::Route *> &routes)
                 QFAIL("Transfer object is INVALID");
             }
         }
-
-        // Verify if the transfer stations are allowed for this trip
-        foreach(QString station, retrievedTransferStations) {
-            //QVERIFY2(possibleTransferStations.contains(station), "Transfer station not known for this trip");
-        }
     }
 }


### PR DESCRIPTION
1. **Explanation**: 
    - Added CSA::Stationfactory memory cache, this reduces the routing by 400 - 500 ms and reduces the memory consumption since only 1 object is created for each station. 
    - Added platforms data to CSA::Station

2. **Fixed issues**: 
    - Fixed #21 

3. **Testing environment**: 
    - Sailfish OS version: 2.2.0.29
    - Sailfish OS hardware: Jolla 1
